### PR TITLE
Heroku deploy #11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     pg (1.4.3)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -193,6 +195,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def top
+  end
+end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,0 +1,2 @@
+<h1>StaticPages#top</h1>
+<p>Find me in app/views/static_pages/top.html.erb</p>

--- a/config/database.yml
+++ b/config/database.yml
@@ -84,3 +84,6 @@ production:
   database: hatsunetsu_kun_production
   username: hatsunetsu_kun
   password: <%= ENV['HATSUNETSU_KUN_DATABASE_PASSWORD'] %>
+  adapter: postgresql
+  encoding: unicode
+  pool: 5

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  root 'static_pages#top'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 概要
close #11 
herokuへのデプロイを行いました。

## 実装手順
1, rootページを作成するためにstatic_pagesコントローラーを作成
```
$ rails g controller static_pages top
```
ルーティングも設定する
```
Rails.application.routes.draw do
  root 'static_pages#top'
end
```

2, Herokuにデプロイするためにdatabase.ymlを編集
```
production:
  <<: *default
  database: hatsunetsu_kun_production
  username: hatsunetsu_kun
  password: <%= ENV['HATSUNETSU_KUN_DATABASE_PASSWORD'] %>
  adapter: postgresql
  # postgreSQLのデータベースに接続
  encoding: unicode
  # unicodeという文字コードを使用
  pool: 5
  # DBに接続できる上限の数を制限
```

3, Herokuにアプリを作成する
```
#herokuにログイン
heroku login

#任意のアプリ名を入力（名前は後から変更可能)
heroku create 好きなアプリの名前
```

4, Herokuにpushする
```
git add .
git commit -m "release to heroku"
今回はmainではないブランチからpushを実行
git push --set-upstream origin heroku_deploy_#11
```

## 確認方法

1. コードの挙動を手元で確認するには以下のコマンドを実行してください
```
git fetch origin pull/13/head:Heroku deploy #11 
```
2. アプリがHeroku上で公開されていることを確認するには以下のURLからアクセスを行なってください。
https://hatsunetsukun.herokuapp.com/
アクセスすると以下のtopページが表示されることが確認できます。
[![Image from Gyazo](https://i.gyazo.com/95e14f2cdfc4141aacabb7b7c6676966.png)](https://gyazo.com/95e14f2cdfc4141aacabb7b7c6676966)

## 影響範囲

新しくコントローラーを作成してdatabaseの設定を変更しただけなので他の作業への影響は少ないと思います。

## コメント
作業中に遭遇したエラーに関してはwikiにまとめてみました。
[[エラー]Failed to install gems via Bundler.](https://github.com/morning-study-party/hatsunetsu-kun/wiki/%5B%E3%82%A8%E3%83%A9%E3%83%BC%5DFailed-to-install-gems-via-Bundler.)
[[エラー]Webpacker can't find application.js](https://github.com/morning-study-party/hatsunetsu-kun/wiki/%5B%E3%82%A8%E3%83%A9%E3%83%BC%5DWebpacker-can't-find-application.js)

また、Herokuデプロイの設定で以下の設定をfalseからtrueに変更することは行いませんでした。
```
config.assets.compile = false
```
理由は記事にあるようにこの記述がなくとも画像を問題なく表示できるからとパフォーマンス低下の恐れがあるからです。
[【2022年版】HerokuでRailsの画像が表示されないときの適切な対処法（と間違った対処法）](https://qiita.com/jnchito/items/3d225112a3ac95379b1d)

## 参考記事
[【初心者向け】railsアプリをherokuを使って確実にデプロイする方法【決定版】
](https://qiita.com/kazukimatsumoto/items/a0daa7281a3948701c39)
