### PR TITLE
近くの病院検索機能を実装#27

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -71,6 +71,16 @@ class LineBotController < ApplicationController
           if /5/.match?(event.message['text'])
             client.reply_message(event['replyToken'], template)
           end
+        when Line::Bot::Event::MessageType::Location
+          latitude = event["message"]["latitude"]
+          longitude = event["message"]["longitude"]
+          user_address = Geocoder.search([latitude,  longitude])
+          user_location = Hospital.create!(name: 'ユーザー現在地', address: user_address.first.address, phone_number:'090', url: 'url', latitude: latitude, longitude: longitude)
+          near_hospitals = user_location.nearbys(5, units: :km)
+          message = near_hospitals.map{|hospital| "#{hospital.name}" }.join("\n")
+          client.reply_message(event['replyToken'],{ type: 'text', text: message })
+          user_location.delete!
+        end
       end
     end
     head :ok

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -68,17 +68,16 @@ class LineBotController < ApplicationController
             }
             client.reply_message(event['replyToken'], message)
           end
-          if /5/.match?(event.message['text'])
-            client.reply_message(event['replyToken'], template)
-          end
+          client.reply_message(event['replyToken'], template) if /5/.match?(event.message['text'])
         when Line::Bot::Event::MessageType::Location
-          latitude = event["message"]["latitude"]
-          longitude = event["message"]["longitude"]
-          user_address = Geocoder.search([latitude,  longitude])
-          user_location = Hospital.create!(name: 'ユーザー現在地', address: user_address.first.address, phone_number:'090', url: 'url', latitude: latitude, longitude: longitude)
+          latitude = event['message']['latitude']
+          longitude = event['message']['longitude']
+          user_address = Geocoder.search([latitude, longitude])
+          user_location = Hospital.create!(name: 'ユーザー現在地', address: user_address.first.address, phone_number: '090',
+                                           url: 'url', latitude:, longitude:)
           near_hospitals = user_location.nearbys(5, units: :km)
-          message = near_hospitals.map{|hospital| "#{hospital.name}" }.join("\n")
-          client.reply_message(event['replyToken'],{ type: 'text', text: message })
+          message = near_hospitals.map { |hospital| hospital.name.to_s }.join("\n")
+          client.reply_message(event['replyToken'], { type: 'text', text: message })
           user_location.delete!
         end
       end
@@ -95,21 +94,21 @@ class LineBotController < ApplicationController
     end
   end
 
-    def template
-  {
-      "type": "template",
-      "altText": "位置検索中",
+  def template
+    {
+      "type": 'template',
+      "altText": '位置検索中',
       "template": {
-          "type": "buttons",
-          "title": "最寄駅探索探索",
-          "text": "現在の位置を送信しますか？",
-          "actions": [
-              {
-                "type": "uri",
-                "label": "位置を送る",
-                "uri": "line://nv/location"
-              }
-          ]
+        "type": 'buttons',
+        "title": '最寄駅探索探索',
+        "text": '現在の位置を送信しますか？',
+        "actions": [
+          {
+            "type": 'uri',
+            "label": '位置を送る',
+            "uri": 'line://nv/location'
+          }
+        ]
       }
     }
   end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -69,13 +69,8 @@ class LineBotController < ApplicationController
             client.reply_message(event['replyToken'], message)
           end
           if /5/.match?(event.message['text'])
-            message = {
-              "type": 'text',
-              "text": '診療可能な病院が○件見つかりました'
-            }
-            client.reply_message(event['replyToken'], message)
+            client.reply_message(event['replyToken'], template)
           end
-        end
       end
     end
     head :ok
@@ -88,5 +83,24 @@ class LineBotController < ApplicationController
       config.channel_secret = Rails.application.credentials.dig(:line, :channel_secret)
       config.channel_token = Rails.application.credentials.dig(:line, :channel_token)
     end
+  end
+
+    def template
+  {
+      "type": "template",
+      "altText": "位置検索中",
+      "template": {
+          "type": "buttons",
+          "title": "最寄駅探索探索",
+          "text": "現在の位置を送信しますか？",
+          "actions": [
+              {
+                "type": "uri",
+                "label": "位置を送る",
+                "uri": "line://nv/location"
+              }
+          ]
+      }
+    }
   end
 end


### PR DESCRIPTION
## 概要
close #27 
以下の2点を実装しました。
・ユーザーの現在地を取得する
・取得した現在地から5km圏内の病院名を取得する

## 実装方法
**位置情報の取得**
- ユーザーが"5"を送信したら位置情報を求めるメッセージが送信されます。
- template使ってますがこっちの方が見やすそうなのでこうしてるだけです。
```ruby
  client.reply_message(event['replyToken'], template) if /5/.match?(event.message['text'])

private

def template
    {
      "type": 'template',
      "altText": '位置検索中',
      "template": {
        "type": 'buttons',
        "title": '最寄駅探索探索',
        "text": '現在の位置を送信しますか？',
        "actions": [
          {
            "type": 'uri',
            "label": '位置を送る',
            "uri": 'line://nv/location'
          }
        ]
      }
    }
  end
```
**取得した位置情報から近くの病院を検索**
```ruby
# メッセージタイプがLocation(位置情報)の場合に実行される
when Line::Bot::Event::MessageType::Location
   # 緯度経度をそれぞれ変数に代入している。今考えるとcreateの引数でまとめて書けばよかった…
   latitude = event['message']['latitude']
   longitude = event['message']['longitude']
   # geocoderで近くの検索を行うには同じモデルのインスタンスでなければならないのでHospitalモデルのインスタンスを作成してる
   # addressを必須項目にしているので住所を入れないとインスタンスを作成できないので緯度経度から住所を取得
   # 住所に適当な文字列を入れる方法だとafter_validationでその適当な文字を元に緯度経度が更新されてしまうので現状はこの方法しかないのかなと思ってる
   user_address = Geocoder.search([latitude, longitude])
  # ユーザーの現在地を取得してる。user_address.first.addressで検索に使える形の住所を取得できる
   user_location = Hospital.create!(name: 'ユーザー現在地', address: user_address.first.address, phone_number: '090',
                                           url: 'url', latitude:, longitude:)
   # geocoderのメソッドで5km圏内の病院を取得
   near_hospitals = user_location.nearbys(5, units: :km)
  # メッセージに病院名を格納して返信する
  message = near_hospitals.map { |hospital| hospital.name.to_s }.join("\n")
  client.reply_message(event['replyToken'], { type: 'text', text: message })
  # ここで削除しないと次回からの検索にユーザーの住所が含まれてしまうので削除してる
  user_location.delete!
```
## 確認方法

行った修正をレビュアーが確認するための手順を記載しましょう。例えば以下のように。

1. ``git fetch origin pull/29/head:search_hospitals_#27``
2. ``rails server``と``ngrok``を起動してください
3. LINE botで"5"と送信して"位置を送るボタンを押してください"
<a href="https://gyazo.com/5b7487b5022ebbc2f56091edde5b54cb"><img src="https://i.gyazo.com/5b7487b5022ebbc2f56091edde5b54cb.png" alt="Image from Gyazo" width="448"/></a>
4.位置情報を送信すると近くの病院名が帰ってきます
<a href="https://gyazo.com/6454483d1ac01a593f25753be52365ee"><img src="https://i.gyazo.com/6454483d1ac01a593f25753be52365ee.png" alt="Image from Gyazo" width="408"/></a> 

## 影響範囲

line botコントローラーしか触っていません。

## コメント
コードについての詳しいドキュメントは今日の夜までには作成しておきます。
以下のようにいくつか懸念点はあるのですが、返信される病院のデザイン等を進めて持ってから修正していく形の方が安心だと思いました。
・病院が一軒も引っ掛からなかった場合の挙動
・病院が大量に引っかかった場合の挙動

## 参考記事
[【LINE bot】最寄駅検索bot](https://qiita.com/4geru/items/30fa69c65e9fcdd12108)
