### PR TITLE
Change: URLと電話番号の追加#47

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -19,19 +19,19 @@ class LineBotController < ApplicationController
                       \n自家用車でのご移動をお願いします
                       \n2.自家用車がない場合
                       \n発熱タクシー（有料）をご検討ください
-                      \n発熱タクシーのURL
+                      \nhttps://www.kaigotaxi-haisha.com/service/detail/id=102
                       \n3.公共交通機関を利用の場合
                       \nもし公共交通機関を利用する場合は感染対策を徹底して人と距離をとり移動すること
                       \n4.上記の移動手段が困難な場合
                       \n救急車をご検討ください。救急車を呼ぶか迷った場合はこちらを参照ください。
-                      \n参考記事のurl"
+                      \nhttps://www.tfd.metro.tokyo.lg.jp/tfd/hp-kyuuimuka/guide/main/index.html"
             }
             client.reply_message(event['replyToken'], message)
           end
           if /コロナまたはCOCOA通知について相談したい方/.match?(event.message['text'])
             message = {
               "type": 'text',
-              "text": "COCOA通知がきて相談したい方は【東京都発熱相談センターCOCOA専用ダイヤル】で相談できます。\n[電話番号]000-0000-0000
+              "text": "COCOA通知がきて相談したい方は【東京都発熱相談センターCOCOA専用ダイヤル】で相談できます。\nhttps://covid19.supportnavi.metro.tokyo.lg.jp/service/EDp1nr1qF93oYS5J
                       \n新型コロナに対して不安に思う方は【新型コロナ・オミクロン株コールセンター】で相談ができます。\n[電話番号]0570-550571"
             }
             client.reply_message(event['replyToken'], message)


### PR DESCRIPTION
## 概要

メッセーっジに
・コロナタクシーのURLと救急車を呼ぶかの判断・発熱センターへのURL・オミクロン株コールセンターへの電話番号を追加しました

## 確認方法

行った修正をレビュアーが確認するための手順を記載しましょう。例えば以下のように。

1. LINE botを起動して「移動手段」または「相談したい方」を押してください
2. 画像のようにURL・電話番号付きのメッセージが表示されます。
<a href="https://gyazo.com/84ec7d5d7fc49af01e6240bdbec9967b"><img src="https://i.gyazo.com/84ec7d5d7fc49af01e6240bdbec9967b.png" alt="Image from Gyazo" width="370"/></a> 
<a href="https://gyazo.com/955a87a42b1a9ed9f20edf08947406f7"><img src="https://i.gyazo.com/955a87a42b1a9ed9f20edf08947406f7.png" alt="Image from Gyazo" width="376"/></a>

## 影響範囲

URLと電話番号を追加しただけなので他へは影響してないと思います！

## コメント

本番までの時間もあるので12時をすぎたらセルフマージします。